### PR TITLE
アカウントメニューの修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,59 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="max-w-3xl mx-auto my-6 bg-white p-8 rounded shadow-md">
+  <h2 class="text-3xl font-bold text-blue-900 mb-8 border-b pb-2">アカウント設定</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name),
+               html: { method: :put, class: "space-y-6" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <!-- メールアドレス -->
+    <div>
+      <%= f.label :email, "メールアドレス", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p class="text-sm text-gray-600">確認待ち: <%= resource.unconfirmed_email %></p>
+    <% end %>
+
+    <!-- 現在のパスワード -->
+    <div>
+      <%= f.label :current_password, "現在のパスワード", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <%= f.password_field :current_password, autocomplete: "current-password",
+            class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <!-- 新しいパスワード -->
+    <div>
+      <%= f.label :password, "新しいパスワード (変更しない場合は空欄)", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <%= f.password_field :password, autocomplete: "new-password",
+            class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+      <% if @minimum_password_length %>
+        <p class="text-xs text-gray-500 mt-1"><%= @minimum_password_length %>文字以上</p>
+      <% end %>
+    </div>
+
+    <!-- パスワード確認 -->
+    <div>
+      <%= f.label :password_confirmation, "新しいパスワード (再確認)", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <!-- 更新ボタン -->
+    <div>
+      <%= f.submit "更新する",
+            class: "w-full bg-blue-900 text-white font-semibold py-3 px-4 rounded hover:bg-blue-800 transition" %>
+    </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <!-- アカウント削除 -->
+  <div class="mt-10 border-t pt-6">
+    <h3 class="text-lg font-bold text-red-700 mb-4">アカウント削除</h3>
+    <p class="text-sm text-gray-600 mb-4">退会すると、これまでの記録もすべて削除されます。</p>
+    <%= button_to "アカウントを削除する", registration_path(resource_name),
+          data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" },
+          method: :delete,
+          class: "w-full bg-red-600 text-white font-semibold py-3 px-4 rounded hover:bg-red-700 transition" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
         <%= link_to "シェア", share_path, class: "mr-5 hover:text-gray-300" %>
       </nav>
       <%# アカウントアイコンをホバーでメニュー表示%>
-      <div class="account-menu relative group flex items-center hover:text-gray-300 hover:cursor-pointer">
+      <div class="account-menu relative group flex items-center hover:text-gray-300">
         <span class="material-symbols-outlined" style="font-size: 36px;">
           account_circle
         </span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,9 +21,6 @@
           <div class="px-4 py-3 text-sm border-b text-gray-500">
             <% if user_signed_in? %>
               <div>
-                <%= "name" %>
-              </div>
-              <div>
                 <%= current_user.email %>
               </div>
             <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -27,7 +27,7 @@
           </div>
           <div class="py-2">
             <%= link_to "アカウント設定", edit_user_registration_path, class: "block px-4 py-2 text-sm text-black hover:bg-gray-100" %>
-            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "block px-4 py-2 text-sm text-black hover:bg-gray-100" %>
+            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "block px-4 py-2 text-sm text-red-600 hover:bg-gray-100" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Issue
close: #22 

## 実施内容
- アカウント設定ページのスタイルを作成
- 名前欄は使用しなかったので削除した
- ログアウトの文字を赤くした
- メニューのうち、「アカウント設定」と「ログアウト」にホバーしたときだけポインターになるようにした

## 課題
特になし

## 備考
特になし