### PR TITLE
ログ一覧にページネーションを追加

### DIFF
--- a/app/controllers/timers_controller.rb
+++ b/app/controllers/timers_controller.rb
@@ -5,15 +5,18 @@ class TimersController < ApplicationController
     @log = current_user.logs.build
     @category = current_user.categories.find_by(id: params[:category_id])
 
-    if @category
-      @logs = current_user.logs
-                        .where(category_id: @category.id)
-                        .order(study_date: :desc)
-                        .order(id: :desc)
-      @today_total_duration = @logs.where(study_date: Date.current).sum(:duration)
-      @total_duration = @logs.sum(:duration)
-    else
+    unless @category
       redirect_to root_path, alert: "無効なカテゴリです" and return
     end
+
+    # 何回もDBにアクセスしないように共通化
+    base_logs = current_user.logs
+                             .where(category_id: @category.id)
+                             .order(study_date: :desc, id: :desc)
+
+    @today_total_duration = base_logs.where(study_date: Date.current).sum(:duration)
+    @total_duration       = base_logs.sum(:duration)
+
+    @logs = base_logs.page(params[:page]).per(10)
   end
 end

--- a/app/views/timers/show.html.erb
+++ b/app/views/timers/show.html.erb
@@ -76,13 +76,14 @@
   </button>
   <% if @logs.present? %>
     <turbo-frame id="logs_frame">
-      <%= paginate @logs %>
-        <ul class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white">
-          <% @logs.each do |log| %>
-            <%= render "logs/log", log: log %>
-          <% end %>
-        </ul>
-      <%= paginate @logs %>
+      <ul class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white">
+        <% @logs.each do |log| %>
+          <%= render "logs/log", log: log %>
+        <% end %>
+      </ul>
+      <div class="flex justify-center my-4">
+        <%= paginate @logs %>
+      </div>
     </turbo-frame>
   <% else %>
     <div class="rounded-xl border border-dashed p-8 text-center text-gray-600 bg-white">

--- a/app/views/timers/show.html.erb
+++ b/app/views/timers/show.html.erb
@@ -75,11 +75,15 @@
       class: "inline-block mb-4 bg-blue-900 text-white font-semibold py-2 px-4 rounded hover:bg-blue-800 hover:cursor-pointer transition" %>
   </button>
   <% if @logs.present? %>
-    <ul class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white">
-      <% @logs.each do |log| %>
-        <%= render "logs/log", log: log %>
-      <% end %>
-    </ul>
+    <turbo-frame id="logs_frame">
+      <%= paginate @logs %>
+        <ul class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white">
+          <% @logs.each do |log| %>
+            <%= render "logs/log", log: log %>
+          <% end %>
+        </ul>
+      <%= paginate @logs %>
+    </turbo-frame>
   <% else %>
     <div class="rounded-xl border border-dashed p-8 text-center text-gray-600 bg-white">
       <p>このカテゴリの学習記録はまだありません。<br>タイマーで「開始」して記録しましょう。</p>


### PR DESCRIPTION
## 目的・概要
- タイマーページのログ一覧が長くなりすぎないよう、ページネーションを追加する。

## Issue
close: #85 

## 実施内容
- timersコントローラにページネーション設定を追加
- タイマーページにページネーション表示を追加

## 備考
- kaminari gemを使用